### PR TITLE
Drop type check for implementation in MatrixSpace constructor

### DIFF
--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -57,6 +57,8 @@ from sage.categories.enumerated_sets import EnumeratedSets
 
 from sage.misc.lazy_import import lazy_import
 from sage.features.meataxe import Meataxe
+lazy_import('sage.matrix.matrix_gfpn_dense', ['Matrix_gfpn_dense'],
+            feature=Meataxe())
 lazy_import('sage.groups.matrix_gps.matrix_group', ['MatrixGroup_base'])
 
 _Semirings = Semirings()
@@ -394,8 +396,7 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
 
         if implementation == 'meataxe':
             if R.is_field() and R.order() < 256:
-                from . import matrix_gfpn_dense
-                return matrix_gfpn_dense.Matrix_gfpn_dense
+                return Matrix_gfpn_dense
             raise ValueError("'meataxe' matrix can only deal with finite fields of order < 256")
 
         if implementation == 'numpy':

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -950,9 +950,6 @@ class MatrixSpace(UniqueRepresentation, Parent):
             sage: MatrixSpace(ZZ,2) in Sets().Infinite()
             True
         """
-        # Checks of input data are supposed to be done in __classcall__
-        assert isinstance(implementation, type)
-
         self.Element = implementation
         self.__nrows = nrows
         self.__ncols = ncols


### PR DESCRIPTION
Drop type check for implementation in MatrixSpace constructor

This doesn't work for meataxe the first time it's called, since it is lazy loaded.

Using an invalid implementation will give a ValueError later anyway.

